### PR TITLE
Use tailwindcss class for dark mode

### DIFF
--- a/jobot-web/tailwind.config.js
+++ b/jobot-web/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx}",
     "./src/components/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
- Fixes title color when system preferences is dark mode

Before:
<img width="951" alt="CleanShot 2023-04-23 at 10 14 34@2x" src="https://user-images.githubusercontent.com/2552115/233820302-7e60e645-1d5a-487f-bca5-c0628f007f4f.png">
After:
<img width="938" alt="CleanShot 2023-04-23 at 10 14 45@2x" src="https://user-images.githubusercontent.com/2552115/233820311-95eb0a62-a778-48e5-bc01-410ab8c4d20d.png">
