### PR TITLE
Fix await in verify otp

### DIFF
--- a/jobot-web/src/pages/api/auth/verify-otp.js
+++ b/jobot-web/src/pages/api/auth/verify-otp.js
@@ -54,7 +54,7 @@ export default async function handler(req, res) {
     return;
   }
 
-  const profile = ensureUserProfile(supabase, user);
+  const profile = await ensureUserProfile(supabase, user);
 
   if (!profile) {
     console.log("unable to create user profile");


### PR DESCRIPTION
Missing await was causing apikey creation before profile creation